### PR TITLE
Commit pending text input before validation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 Changes on `main` will be listed here.
 
+### Bug Fixes
+
+-   [[#8](https://github.com/diatche/react-native-form-model/pull/8)] Fixed a bug where a text input's latest pending value would not be commited in some native UI situations.
+
 ## 0.4.2
 
 1 Jul 2021

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -153,6 +153,12 @@ const FormField: React.FC<FormFieldProps> = ({
         const editingStateRef = React.useRef<InputFieldState<any> | undefined>(
             undefined
         );
+        const commitState = () =>
+            editingStateRef.current && field.setState(editingStateRef.current);
+
+        field.delegate = {
+            willValidate: commitState,
+        };
         invisibleContainerField = (
             <TextInputField
                 {...otherProps}
@@ -178,10 +184,7 @@ const FormField: React.FC<FormFieldProps> = ({
                         field.setState(state);
                     }
                 }}
-                onBlur={() =>
-                    editingStateRef.current &&
-                    field.setState(editingStateRef.current)
-                }
+                onBlur={commitState}
                 parse={x => field.parseState(x)}
                 format={x => field.formatValue(x)}
                 validate={x => field.normalizedValidationResult(x)}
@@ -333,6 +336,15 @@ const FormField: React.FC<FormFieldProps> = ({
             const editingStateRef = React.useRef<
                 InputFieldState<any> | undefined
             >(undefined);
+
+            const commitState = () =>
+                editingStateRef.current &&
+                field.setState(editingStateRef.current);
+
+            field.delegate = {
+                willValidate: commitState,
+            };
+
             invisibleContainerField = (
                 <TimeInputField
                     {...otherProps}
@@ -350,10 +362,7 @@ const FormField: React.FC<FormFieldProps> = ({
                     onValueChange={state => {
                         editingStateRef.current = state;
                     }}
-                    onBlur={() =>
-                        editingStateRef.current &&
-                        field.setState(editingStateRef.current)
-                    }
+                    onBlur={commitState}
                     align={field.align}
                     style={[
                         styles.container,

--- a/src/models/FieldModel/InputFieldModel.ts
+++ b/src/models/FieldModel/InputFieldModel.ts
@@ -33,6 +33,10 @@ export interface InputFieldModelOptions<T, I = string>
     validation?: (value?: T) => InputFieldValidationValue;
 }
 
+export interface InputFieldModelDelegate<T, I> {
+    willValidate: (field: InputFieldModel<T, I>) => void;
+}
+
 export type ParsedInputFieldModelOptions<T, I> = Omit<
     InputFieldModelOptions<T, I>,
     'parseInput'
@@ -53,6 +57,7 @@ export default class InputFieldModel<T, I = string>
     formatValue: (value: T | undefined) => string;
     validation?: (value?: T) => InputFieldValidationValue;
     viewRef?: InputFieldViewRef;
+    delegate?: InputFieldModelDelegate<T, I>;
 
     private _onValueChangeCb?: InputFieldModelOptions<T, I>['onValueChange'];
 
@@ -187,6 +192,7 @@ export default class InputFieldModel<T, I = string>
     }
 
     validate(): InputFieldValidationResult {
+        this.delegate?.willValidate(this);
         let { valid = true, error } = this.normalizedValidationResult(
             this.value.value
         );


### PR DESCRIPTION
### Bug Fixes

-   Fixed a bug where a text input's latest pending value would not be commited in some native UI situations.