### PR TITLE
Keyboard input contained mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 Changes on `main` will be listed here.
 
+### Features
+
+-   Added `mode` property to keyboard input and time inputs. There are two modes, `plain` and `contained`. The default mode is `plain` (matches the previous style).
+
+### Bug Fixes
+
+-   Fixed a bug where a time input field height would be smaller than the row.
+
 ## 0.4.4
 
 3 Aug 2021

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -191,10 +191,7 @@ class DatePicker extends Component<DatePickerProps, DatePickerState> {
                 this.onCancel();
                 break;
             default:
-                console.warn(
-                    'Received unknown DatePicker event: ' +
-                        JSON.stringify(event, null, 4)
-                );
+                console.warn('Received unknown DatePicker event:', event);
         }
     }
 

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -196,6 +196,7 @@ const FormField: React.FC<FormFieldProps> = ({
                 clearTextOnFocus={field.clearTextOnFocus}
                 clearButtonMode={field.clearButtonMode}
                 align={field.align}
+                mode={field.mode}
                 style={[
                     styles.container,
                     containerStyle,
@@ -363,6 +364,7 @@ const FormField: React.FC<FormFieldProps> = ({
                     }}
                     onBlur={commitState}
                     align={field.align}
+                    mode={field.mode}
                     style={[
                         styles.container,
                         containerStyle,

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -69,7 +69,6 @@ const FormField: React.FC<FormFieldProps> = ({
         paddingBottom: formStyle.paddingBottom,
     };
     const fieldWithBorderStyle: ViewStyle = {
-        ...getFieldWithBorderStyle(theme),
         borderRadius: Math.max(0, formStyle.roundness - 3),
         borderWidth: 0,
         marginLeft: 3,
@@ -419,6 +418,7 @@ const FormField: React.FC<FormFieldProps> = ({
                             styles.container,
                             containerStyle,
                             fieldWithBorderStyle,
+                            getPickerStyle(theme),
                             inputTextStyle,
                         ]}
                         align={field.align}
@@ -532,7 +532,7 @@ const styles = StyleSheet.create({
     },
 });
 
-const getFieldWithBorderStyle = (theme: PaperThemeWithForm) => {
+const getPickerStyle = (theme: PaperThemeWithForm) => {
     // We selectively apply backround, because web needs it,
     // and Android has a bug with background color when using
     // it with Picker.

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -70,7 +70,6 @@ const FormField: React.FC<FormFieldProps> = ({
     };
     const fieldWithBorderStyle: ViewStyle = {
         borderRadius: Math.max(0, formStyle.roundness - 3),
-        borderWidth: 0,
         marginLeft: 3,
         marginRight: 3,
         marginTop: 3,
@@ -204,6 +203,7 @@ const FormField: React.FC<FormFieldProps> = ({
                     styleProp,
                 ]}
                 textStyle={inputTextStyle}
+                formStyle={formStyle}
                 theme={theme}
             />
         );
@@ -370,6 +370,7 @@ const FormField: React.FC<FormFieldProps> = ({
                         styleProp,
                     ]}
                     textStyle={inputTextStyle}
+                    formStyle={formStyle}
                     theme={theme}
                 />
             );

--- a/src/components/FormField.tsx
+++ b/src/components/FormField.tsx
@@ -53,10 +53,12 @@ const FormField: React.FC<FormFieldProps> = ({
     const theme = useTheme() as PaperThemeWithForm;
     const formStyle = field.resolveStyle(theme.form);
     const justifyContent = kAlignmentToJustifyContentMap[field.align];
-    const innerContainerStyle: ViewStyle = {
-        flex: field.flex ? field.flex : undefined,
+    let innerContainerStyle: ViewStyle = {
         justifyContent,
     };
+    if (field.flex) {
+        innerContainerStyle.flex = field.flex;
+    }
     const containerStyle: ViewStyle = {
         ...innerContainerStyle,
         marginLeft: formStyle.marginLeft,

--- a/src/components/LabelField.tsx
+++ b/src/components/LabelField.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View, ViewStyle, StyleProp, TextStyle, FlexStyle } from 'react-native';
 import { Text, Caption, TouchableRipple } from 'react-native-paper';
 import _ from 'lodash';
-import { PaperThemeWithForm } from '../models/FormStyle';
+import { FormStyle, PaperThemeWithForm } from '../models/FormStyle';
 
 export type Alignment = 'left' | 'center' | 'right';
 
@@ -24,6 +24,7 @@ export interface LabelFieldProps<T> extends Omit<ViewStyle, 'value'> {
     align?: Alignment;
     style?: StyleProp<TextStyle>;
     textStyle?: StyleProp<TextStyle>;
+    formStyle?: FormStyle;
     rippleColor?: string;
     disabled?: boolean;
     /**

--- a/src/components/TextInputField.tsx
+++ b/src/components/TextInputField.tsx
@@ -6,8 +6,10 @@ import ControlField, {
 } from './ControlField';
 import {
     Platform,
+    StyleSheet,
     TextInput as NativeTextInput,
     TextInputProps,
+    ViewStyle,
 } from 'react-native';
 
 const isWeb = Platform.OS === 'web';
@@ -45,6 +47,7 @@ export interface TextInputFieldProps<T>
     extends ControlFieldProps<T, string>,
         TextInputForwardProps {
     secure?: boolean;
+    mode?: 'plain' | 'contained';
 }
 export interface TextInputFieldState<T> extends ControlFieldState<T, string> {}
 
@@ -77,10 +80,24 @@ export default class TextInputField<T = string> extends ControlField<
             style = {},
             textStyle = {},
             multiline = false,
+            mode = 'contained',
         } = this.props;
         const { userInput = '', error } = this.state;
 
         const { textAlignVertical = multiline ? 'top' : 'auto' } = this.props;
+
+        let modeStyle: ViewStyle = {};
+        switch (mode) {
+            case 'plain':
+                break;
+            case 'contained':
+                modeStyle = {
+                    backgroundColor: theme.form.colors.containedTextBackground,
+                };
+                break;
+            default:
+                console.warn('Unrecognized TextInputField mode:', mode);
+        }
 
         const forwardProps = _.omit(this.props, kOmitTextInputProps);
 
@@ -97,7 +114,12 @@ export default class TextInputField<T = string> extends ControlField<
             },
             clearTextOnFocus,
             secureTextEntry: secure,
-            style: [isWeb ? kTextFieldWebStyle : undefined, style, textStyle],
+            style: [
+                isWeb ? kTextFieldWebStyle : undefined,
+                modeStyle,
+                style,
+                textStyle,
+            ],
             selectionColor: theme.colors.primary,
             textAlignVertical,
         };
@@ -116,6 +138,8 @@ export default class TextInputField<T = string> extends ControlField<
         );
     }
 }
+
+const styles = StyleSheet.create({});
 
 const kTextFieldWebStyle: any = {
     /** Remove browser specific styling. */

--- a/src/components/TextInputField.tsx
+++ b/src/components/TextInputField.tsx
@@ -82,7 +82,7 @@ export default class TextInputField<T = string> extends ControlField<
             textStyle = {},
             formStyle,
             multiline = false,
-            mode = 'contained',
+            mode = 'plain',
         } = this.props;
         const { userInput = '', error } = this.state;
 

--- a/src/components/TextInputField.tsx
+++ b/src/components/TextInputField.tsx
@@ -11,6 +11,7 @@ import {
     TextInputProps,
     ViewStyle,
 } from 'react-native';
+import { FormStyle } from '../models/FormStyle';
 
 const isWeb = Platform.OS === 'web';
 
@@ -79,6 +80,7 @@ export default class TextInputField<T = string> extends ControlField<
             clearTextOnFocus = false,
             style = {},
             textStyle = {},
+            formStyle,
             multiline = false,
             mode = 'contained',
         } = this.props;
@@ -91,9 +93,7 @@ export default class TextInputField<T = string> extends ControlField<
             case 'plain':
                 break;
             case 'contained':
-                modeStyle = {
-                    backgroundColor: theme.form.colors.containedTextBackground,
-                };
+                modeStyle = getContainedTextFieldStyle(formStyle);
                 break;
             default:
                 console.warn('Unrecognized TextInputField mode:', mode);
@@ -138,6 +138,14 @@ export default class TextInputField<T = string> extends ControlField<
         );
     }
 }
+
+const getContainedTextFieldStyle = (style?: FormStyle) => {
+    return {
+        backgroundColor: style?.colors.containedTextBackground,
+        borderWidth: style?.containedTextBorderWidth,
+        borderColor: style?.colors.containedTextBorder,
+    };
+};
 
 const styles = StyleSheet.create({});
 

--- a/src/components/TimeInputField.tsx
+++ b/src/components/TimeInputField.tsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { StyleSheet } from 'react-native';
 import TextInputField, { TextInputFieldProps } from './TextInputField';
 import { parseTimeOfDay } from '@diatche/parse-time';
 import moment, { Duration } from 'moment';
@@ -55,6 +56,7 @@ export default class TimeInputField extends Component<
         return (
             <TextInputField<Duration | undefined>
                 {...this.props}
+                style={[styles.container, this.props.style]}
                 ref={this.textInputRef}
                 parse={args => this.parse(args)}
                 format={args => this.format(args)}
@@ -65,3 +67,9 @@ export default class TimeInputField extends Component<
         );
     }
 }
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+    },
+});

--- a/src/models/FieldModel/KeyboardInputFieldModel.ts
+++ b/src/models/FieldModel/KeyboardInputFieldModel.ts
@@ -13,6 +13,7 @@ export interface KeyboardInputFieldModelBaseOptions
     > {
     optional?: boolean;
     autoFocus?: boolean;
+    mode?: 'plain' | 'contained';
 }
 
 export interface KeyboardInputFieldModelOwnOptions
@@ -52,6 +53,7 @@ export default class KeyboardInputFieldModel<T>
     implements KeyboardInputFieldModelOwnOptions
 {
     type: KeyboardInputFieldType;
+    mode: KeyboardInputFieldModelOwnOptions['mode'] | undefined;
     keyboardType: KeyboardTypeOptions;
     textContentType: TextInputProps['textContentType'] | undefined;
     optional: boolean;
@@ -70,6 +72,7 @@ export default class KeyboardInputFieldModel<T>
         };
         super(optionsWithDefaults);
         this.type = optionsWithDefaults.type;
+        this.mode = optionsWithDefaults.mode;
         this.validation = optionsWithDefaults.validation;
         this.keyboardType = optionsWithDefaults.keyboardType;
         this.textContentType = optionsWithDefaults.textContentType;
@@ -109,9 +112,10 @@ export type KeyboardInputFieldModelDefaults<T> = Omit<
 let _defaults = (
     options: KeyboardInputFieldModelOptions<any>
 ): KeyboardInputFieldModelDefaults<any> => {
-    const { type = 'text', optional = false } = options;
+    const { type = 'text', mode = 'plain', optional = false } = options;
     const sharedDefaults = {
         type,
+        mode,
         optional,
     };
     switch (type) {

--- a/src/models/FieldModel/TimeInputFieldModel.ts
+++ b/src/models/FieldModel/TimeInputFieldModel.ts
@@ -19,6 +19,7 @@ export default class TimeInputFieldModel
     extends InputFieldModel<Duration, Duration>
     implements TimeInputFieldModelOptions
 {
+    mode: TimeInputFieldModelOptions['mode'] | undefined;
     refDay: MaybeObservable<Moment | undefined> | undefined;
     futureDisabled: boolean;
     autoFocus: boolean;
@@ -55,6 +56,7 @@ export default class TimeInputFieldModel
             validation,
         });
         let {
+            mode = 'plain',
             autoFocus = false,
             futureDisabled = false,
             optional = false,
@@ -62,6 +64,7 @@ export default class TimeInputFieldModel
             selectTextOnFocus = false,
             clearButtonMode = 'never',
         } = options;
+        this.mode = mode;
         this.refDay = options.refDay;
         this.futureDisabled = futureDisabled;
         this.autoFocus = autoFocus;

--- a/src/models/FormStyle.ts
+++ b/src/models/FormStyle.ts
@@ -28,6 +28,8 @@ export interface FormStyle {
     sectionTitleAlign?: TextStyle['textAlign'];
     sectionFooterAlign?: TextStyle['textAlign'];
 
+    containedTextBorderWidth?: number;
+
     colors: FormColors;
 
     paddingLeft?: number;
@@ -54,6 +56,7 @@ export interface FormColors {
     sectionFooter?: string;
     divider?: string;
     formBackground?: string;
+    containedTextBorder?: string;
     containedTextBackground?: string;
 }
 
@@ -70,6 +73,7 @@ export const kDefaultLightFormColors: RequiredFormColors = {
     sectionTitle: Colors.grey700,
     sectionFooter: Colors.grey700,
     divider: Colors.grey200,
+    containedTextBorder: Colors.grey300,
     containedTextBackground: Colors.grey200,
 };
 
@@ -84,6 +88,7 @@ export const kDefaultDarkFormColors: RequiredFormColors = {
     sectionTitle: Colors.grey300,
     sectionFooter: Colors.grey300,
     divider: Colors.grey800,
+    containedTextBorder: Colors.grey700,
     containedTextBackground: Colors.grey800,
 };
 
@@ -98,6 +103,8 @@ export const kDefaultFormStyle: Required<FormStyle> = {
     inputFontWeight: 'normal',
     sectionTitleAlign: 'auto',
     sectionFooterAlign: 'auto',
+
+    containedTextBorderWidth: 1,
 
     colors: kDefaultLightFormColors,
 

--- a/src/models/FormStyle.ts
+++ b/src/models/FormStyle.ts
@@ -54,6 +54,7 @@ export interface FormColors {
     sectionFooter?: string;
     divider?: string;
     formBackground?: string;
+    containedTextBackground?: string;
 }
 
 export type RequiredFormColors = Required<Omit<FormColors, 'formBackground'>>;
@@ -69,6 +70,7 @@ export const kDefaultLightFormColors: RequiredFormColors = {
     sectionTitle: Colors.grey700,
     sectionFooter: Colors.grey700,
     divider: Colors.grey200,
+    containedTextBackground: Colors.grey200,
 };
 
 export const kDefaultDarkFormColors: RequiredFormColors = {
@@ -82,6 +84,7 @@ export const kDefaultDarkFormColors: RequiredFormColors = {
     sectionTitle: Colors.grey300,
     sectionFooter: Colors.grey300,
     divider: Colors.grey800,
+    containedTextBackground: Colors.grey800,
 };
 
 export const kDefaultFormStyle: Required<FormStyle> = {


### PR DESCRIPTION
### Features

-   Added `mode` property to keyboard input and time inputs. There are two modes, `plain` and `contained`. The default mode is `plain` (matches the previous style).

### Bug Fixes

-   Fixed a bug where a time input field height would be smaller than the row.